### PR TITLE
Link into the listing page from stats parts of the homepage

### DIFF
--- a/profiles/static/profiles/js/home-graphs.js
+++ b/profiles/static/profiles/js/home-graphs.js
@@ -91,6 +91,15 @@ $(document).ready(function() {
         };
 
         const chart = new google.visualization.GeoChart(document.getElementById(divId));
+
+        google.visualization.events.addListener(chart, 'select', function() {
+            const selection = chart.getSelection();
+            if (selection.length > 0) {
+                const country = data.getValue(selection[0].row, 0);
+                window.location.href = '/list?s=' + encodeURIComponent(country);
+            }
+        });
+
         chart.draw(data, options);
     }
 

--- a/profiles/templates/profiles/home.html
+++ b/profiles/templates/profiles/home.html
@@ -115,7 +115,7 @@
 <div class="container-fluid" id="stats">
 	<div class="text-center m-4" id="entries-container">
 		<p class="h1 text-secondary font-weight-bold mb-0" id="entries-number"> </p>
-		<p class="h5 text-primary" id="entries-text">entries in repository. </p>
+		<p class="h5 text-primary" id="entries-text"><a href="{% url 'profiles:index' %}">entries in repository</a>.</p>
 	</div>
 
 	<div class="d-flex flex-wrap justify-content-center align-items-start m-4" id="chart-stats">
@@ -129,7 +129,7 @@
 				</tr>
 			</table>
 			<span class="position-title text-secondary" id="PhDtext">PhD</span>
-			<p id="student-count" class="position-text"> profiles</p>
+			<p class="position-text"><a href="list?s=PhD%20student" id="student-count"> profiles</a></p>
 		</div>
 		<div class="p-2 text-center donutTab">
 			<table>
@@ -141,7 +141,7 @@
 				</tr>
 			</table>
 			<span class="position-title text-tertiary" id="PostDoctext">Post-doc</span>
-			<p id="postdoc-count" class="position-text"> profiles</p>
+			<p class="position-text"><a href="list?s=post-doc" id="postdoc-count"> profiles</a></p>
 		</div>
 		<div class="p-2 text-center donutTab">
 			<table>
@@ -153,7 +153,7 @@
 				</tr>
 			</table>
 			<span class="position-title text-quaternary" id="Seniortext">Senior</span>
-			<p id="senior-count" class="position-text"> profiles</p>
+			<p class="position-text"><a href="list?senior=on" id="senior-count"> profiles</a></p>
 		</div>
 		<div class="p-2 text-center donutTab">
 			<table>


### PR DESCRIPTION
The first thing I did when I saw the directory (well, the WiML fork) was try to click on a country in the map to see the entries from that country, but nothing happened. This makes that happen.

I also linked e.g. "542 profiles" under PhD to search, and Post-doc and Senior; there doesn't seem to be a nice way to search by Other currently, and I didn't really feel like making UI for that, though that would be a good thing to do too.

For good measure, I also linked "entries in repository" at top to the listing page too.

(I hardcoded the `list` url, because other parts of the code did that too, but used `{% url %}` for the index page because other parts of the code did that too. Happy to change all of them, except the JS I guess, to `{% url %}` if that's nicer for whatever reason.)