### PR TITLE
Phase 1 (part 1): email backend, security hardening, code cleanup & docs

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -10,6 +10,14 @@ DB_PASSWORD=
 DB_HOST=
 
 # --- Email (leave empty for local dev — emails print to console) ---
+# Production uses Brevo's SMTP relay. To send real email, set:
+#   EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+#   EMAIL_HOST=smtp-relay.brevo.com
+#   EMAIL_PORT=587
+#   EMAIL_USE_TLS=true
+#   EMAIL_HOST_USER=<brevo-smtp-login>
+#   EMAIL_HOST_PASSWORD=<brevo-smtp-key>
+#   DEFAULT_FROM_EMAIL=<verified-sender@domain>
 EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend
 EMAIL_HOST=
 EMAIL_PORT=0

--- a/.env.default
+++ b/.env.default
@@ -30,17 +30,17 @@ DEFAULT_REPLY_TO_EMAIL=noreply@localhost
 
 # --- Security headers (production hardening; safe defaults are off) ---
 # X-Content-Type-Options, X-Frame-Options and Referrer-Policy are always on.
-# Enable these in production once HTTPS is verified on PythonAnywhere:
+# In production, once HTTPS is verified on PythonAnywhere, raise these:
 #   SECURE_SSL_REDIRECT=true      # redirect http -> https
 #   SECURE_HSTS_SECONDS=31536000  # start lower (e.g. 3600) to test, then ramp
-SECURE_SSL_REDIRECT=
-SECURE_HSTS_SECONDS=
+SECURE_SSL_REDIRECT=false
+SECURE_HSTS_SECONDS=0
 
 # --- Rate limiting (login brute-force protection) ---
 # RATELIMIT_ENABLE acts as a kill-switch (set to false to disable in prod).
 # LOGIN_RATELIMIT is the per-IP cap on login POSTs, e.g. 10/m, 20/h.
-RATELIMIT_ENABLE=
-LOGIN_RATELIMIT=
+RATELIMIT_ENABLE=true
+LOGIN_RATELIMIT=10/m
 
 # --- reCAPTCHA (Google test keys — always pass) ---
 RECAPTCHA_PUBLIC_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI

--- a/.env.default
+++ b/.env.default
@@ -28,6 +28,14 @@ EMAIL_HOST_PASSWORD=
 DEFAULT_FROM_EMAIL=noreply@localhost
 DEFAULT_REPLY_TO_EMAIL=noreply@localhost
 
+# --- Security headers (production hardening; safe defaults are off) ---
+# X-Content-Type-Options, X-Frame-Options and Referrer-Policy are always on.
+# Enable these in production once HTTPS is verified on PythonAnywhere:
+#   SECURE_SSL_REDIRECT=true      # redirect http -> https
+#   SECURE_HSTS_SECONDS=31536000  # start lower (e.g. 3600) to test, then ramp
+SECURE_SSL_REDIRECT=
+SECURE_HSTS_SECONDS=
+
 # --- reCAPTCHA (Google test keys — always pass) ---
 RECAPTCHA_PUBLIC_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
 RECAPTCHA_PRIVATE_KEY=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe

--- a/.env.default
+++ b/.env.default
@@ -36,6 +36,12 @@ DEFAULT_REPLY_TO_EMAIL=noreply@localhost
 SECURE_SSL_REDIRECT=
 SECURE_HSTS_SECONDS=
 
+# --- Rate limiting (login brute-force protection) ---
+# RATELIMIT_ENABLE acts as a kill-switch (set to false to disable in prod).
+# LOGIN_RATELIMIT is the per-IP cap on login POSTs, e.g. 10/m, 20/h.
+RATELIMIT_ENABLE=
+LOGIN_RATELIMIT=
+
 # --- reCAPTCHA (Google test keys — always pass) ---
 RECAPTCHA_PUBLIC_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
 RECAPTCHA_PRIVATE_KEY=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,25 +1,74 @@
 # Contributing to WiNRepo
 
-Thank you for your interest in contributing!
+Thank you for your interest in contributing! This guide covers the development
+workflow. For first-time setup (virtualenv, database, running the server), see
+the **Quick Start** in [README.md](README.md).
+
+## TL;DR
+
+```bash
+git checkout -b my-change          # branch off main
+python manage.py test              # confirm green before you start
+# ... make your change, add tests ...
+python manage.py test              # confirm green before you push
+git commit -m "fix(profiles): ..." # conventional commit message
+# open a PR against main
+```
 
 ## Getting Started
 
 1. Fork the repository and clone your fork.
-2. Follow the setup instructions in [README.md](README.md).
+2. Follow the **Quick Start** in [README.md](README.md) to get a running dev
+   environment (Python 3.10, `.venv`, `cp .env.default .env`,
+   `./tools/refresh_db.sh`, `python manage.py runserver`).
 3. Create a branch from `main` for your changes.
+
+The default `.env.default` is safe for local work out of the box: it uses
+SQLite, prints emails to the console, and uses Google's always-pass reCAPTCHA
+test keys. You do **not** need any real credentials to develop locally.
 
 ## Development Workflow
 
-1. Make sure existing tests pass before starting: `python manage.py test`
-2. Write tests for new features or bug fixes.
-3. Keep commits focused — one logical change per commit.
-4. Run tests again before submitting your PR.
+1. **Start from green.** Run `python manage.py test` before you change anything,
+   so you know any later failure is yours.
+2. **Test before you touch.** If you're changing existing behaviour, first add a
+   test that captures the *current* behaviour, watch it pass, then make your
+   change. This is how we keep regressions out of a 5-year-old codebase.
+3. **Write tests for new features and bug fixes.** Put them in
+   `profiles/tests/` next to the related `test_*.py` file.
+4. **Keep commits focused** — one logical change per commit.
+5. **Run tests again before submitting** your PR:
+   ```bash
+   python manage.py test
+   ```
+   For coverage:
+   ```bash
+   coverage run --source=profiles manage.py test && coverage report
+   ```
+
+## Commit Messages
+
+We use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+type(scope): short summary in the imperative mood
+
+Optional body explaining the what and why.
+```
+
+Common types in this repo: `feat`, `fix`, `refactor`, `test`, `docs`, `style`,
+`chore`, `ci`, `build`. Scope is the area touched, e.g. `fix(signup): ...`,
+`feat(profiles): ...`, `ci(deploy): ...`.
 
 ## Pull Requests
 
 - Link your PR to any related issues (e.g., "Closes #42").
 - Provide a clear description of what changed and why.
+- Make sure CI is green — pushes run the test suite automatically.
 - Don't include unrelated changes in the same PR.
+
+A push to `main` triggers the deploy workflow (tests, then deploy to
+PythonAnywhere), so `main` must always stay green.
 
 ## Coding Style
 
@@ -27,6 +76,50 @@ Thank you for your interest in contributing!
 - Use clear, descriptive names for variables, functions, and arguments.
 - Keep templates and JS consistent with existing patterns.
 
+## Project Map
+
+A quick orientation — most work happens in the `profiles` app:
+
+| Path | What's there |
+|------|--------------|
+| `profiles/models.py` | Core data models (Profile, Recommendation, Publication, Country, User) |
+| `profiles/views.py` | Page and form views, including sign-up and profile flows |
+| `profiles/forms.py` | Django forms and validation (incl. honeypot / disposable-email checks) |
+| `profiles/emails.py` | Email message builders |
+| `profiles/templates/` | HTML templates |
+| `profiles/static/` | CSS and JS |
+| `profiles/tests/` | Test suite (`test_*.py`) |
+| `winrepo/settings.py` | Project settings (reads from `.env`) |
+| `tools/` | Helper scripts (see below) |
+
+## Helper Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `tools/refresh_db.sh` | (Re)create the local SQLite dev database with sample fixtures |
+| `tools/backup_db.sh` | Back up the database (used in production) |
+| `tools/refresh_env.sh` | Production deploy script (pull, migrate, collectstatic, restart) |
+
+## Common Tasks
+
+```bash
+# Reset your local database to a clean state with sample data
+./tools/refresh_db.sh
+
+# Create an admin user (if you didn't use the seeded `admin`/`admin`)
+python manage.py createsuperuser
+
+# Run a single test module
+python manage.py test profiles.tests.test_signup
+```
+
+> **Note on profiles vs. users:** historically some profiles exist without an
+> associated user account. When working on anything that links profiles and
+> users, don't assume a one-to-one mapping — handle the "profile with no user"
+> case explicitly.
+
 ## Reporting Issues
 
-To report a bug or suggest a feature, [open an issue](https://github.com/WomenInNeuroscience/winrepo/issues/new). Please include steps to reproduce for bugs.
+To report a bug or suggest a feature,
+[open an issue](https://github.com/WomenInNeuroscience/winrepo/issues/new).
+Please include steps to reproduce for bugs.

--- a/profiles/adapter.py
+++ b/profiles/adapter.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from allauth.utils import email_address_exists
 from django.conf import settings
 from django.shortcuts import redirect, resolve_url
@@ -7,6 +6,8 @@ from allauth.account.adapter import DefaultAccountAdapter, get_adapter
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.exceptions import ImmediateHttpResponse
 from allauth.socialaccount import providers
+
+from .redirects import resolve_post_auth_redirect
 
 
 class AccountAdapter(DefaultAccountAdapter):
@@ -34,18 +35,9 @@ class AccountAdapter(DefaultAccountAdapter):
 
     def get_login_redirect_url(self, request):
         assert request.user.is_authenticated
-
-        # TODO deduplicate code with views.py
-        if request.session.get('next') and \
-            request.session.get('next_expiration'):
-
-            if datetime.timestamp(datetime.now()) < request.session['next_expiration']:
-                return request.session.get('next')
-
-        if self.request.session.get('first_login', False):
-            return resolve_url('profiles:user_profile')
-
-        return resolve_url(settings.LOGIN_REDIRECT_URL)
+        return resolve_post_auth_redirect(
+            request.session, resolve_url(settings.LOGIN_REDIRECT_URL)
+        )
 
     def respond_user_inactive(self, request, user):
         messages.warning(request, "Your account is inactive. Please check your email for the activation link.")

--- a/profiles/forms.py
+++ b/profiles/forms.py
@@ -27,7 +27,6 @@ DISPOSABLE_EMAIL_DOMAINS = frozenset({
     'tarogad.online',
     'apacheodyssey.com',
     'acetylcholgh.ru',
-    'rambler.ru',
     'mnmnm.biz',
     'bluroo.com',
     'geruestbau.com',

--- a/profiles/redirects.py
+++ b/profiles/redirects.py
@@ -1,0 +1,31 @@
+"""Shared post-authentication redirect resolution.
+
+The same "where do we send a just-authenticated user?" decision was duplicated
+across ``LoginView``, ``UserCreateConfirmView`` and the allauth account
+adapter. This centralises it so the three stay in sync.
+"""
+from datetime import datetime
+
+from django.shortcuts import resolve_url
+
+
+def resolve_post_auth_redirect(session, fallback):
+    """Resolve where to send a just-authenticated user.
+
+    Priority:
+      1. A non-expired ``next`` URL stashed in the session (set by the login
+         view after host/scheme validation).
+      2. The profile page on a user's first login.
+      3. ``fallback`` — the caller-specific default, returned unchanged.
+
+    ``session`` is a request session (or any mapping); ``fallback`` is an
+    already-resolved URL string.
+    """
+    if session.get('next') and session.get('next_expiration'):
+        if datetime.timestamp(datetime.now()) < session['next_expiration']:
+            return session['next']
+
+    if session.get('first_login', False):
+        return resolve_url('profiles:user_profile')
+
+    return fallback

--- a/profiles/signals.py
+++ b/profiles/signals.py
@@ -1,9 +1,22 @@
-from datetime import datetime, timedelta
+from django.contrib.auth.models import update_last_login
 from django.contrib.auth.signals import user_logged_in
 
+
 def detect_first_login(sender, user, request, **kwargs):
+    # ``last_login`` is None only on a user's very first login. Django's own
+    # ``update_last_login`` receiver overwrites it on every login, so ours
+    # must observe the value *before* that happens (see ordering below).
     if user.last_login is None:
         request.session['first_login'] = True
 
-user_logged_in.connect(detect_first_login)
-user_logged_in.receivers = user_logged_in.receivers[-1:] + user_logged_in.receivers[:-1] 
+
+# Django has no receiver-priority API. Rather than blindly rotating the whole
+# ``user_logged_in`` receiver list (the previous approach, which also disturbed
+# unrelated receivers such as allauth's), order only the two receivers we care
+# about: drop Django's built-in updater, connect ours, then reconnect the
+# updater so it runs afterwards. dispatch_uids keep this idempotent.
+user_logged_in.disconnect(dispatch_uid="update_last_login")
+user_logged_in.connect(
+    detect_first_login, dispatch_uid="profiles.detect_first_login"
+)
+user_logged_in.connect(update_last_login, dispatch_uid="update_last_login")

--- a/profiles/tests/test_ratelimit.py
+++ b/profiles/tests/test_ratelimit.py
@@ -1,0 +1,47 @@
+from http import HTTPStatus
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from ..models import User
+
+
+@override_settings(RATELIMIT_ENABLE=True, LOGIN_RATELIMIT='3/m')
+class LoginRateLimitTests(TestCase):
+    """Login POSTs are rate-limited per IP to blunt brute-force guessing."""
+
+    def setUp(self):
+        cache.clear()  # ratelimit counters live in the cache
+        self.url = reverse('profiles:login')
+        self.user = User.objects.create_user(
+            email='real@test.com', password='RightPass1!', username='real',
+        )
+
+    def _post(self, password):
+        return self.client.post(
+            self.url, {'username': 'real', 'password': password}
+        )
+
+    def test_login_succeeds_within_limit(self):
+        response = self._post('RightPass1!')
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
+        self.assertIn('_auth_user_id', self.client.session)
+
+    def test_login_blocked_after_too_many_attempts(self):
+        # Exhaust the 3/min budget with wrong passwords.
+        for _ in range(3):
+            self._post('wrong')
+        # The next attempt is rate-limited even with the correct password.
+        response = self._post('RightPass1!')
+        self.assertEqual(response.status_code, HTTPStatus.OK)  # re-rendered
+        self.assertNotIn('_auth_user_id', self.client.session)
+
+    def test_rate_limiting_can_be_disabled(self):
+        with override_settings(RATELIMIT_ENABLE=False):
+            for _ in range(5):
+                self._post('wrong')
+            # With limiting off, correct credentials still authenticate.
+            response = self._post('RightPass1!')
+            self.assertEqual(response.status_code, HTTPStatus.FOUND)
+            self.assertIn('_auth_user_id', self.client.session)

--- a/profiles/tests/test_redirects.py
+++ b/profiles/tests/test_redirects.py
@@ -1,0 +1,56 @@
+from datetime import datetime, timedelta
+
+from django.test import TestCase
+from django.urls import reverse
+
+from ..redirects import resolve_post_auth_redirect
+
+
+class ResolvePostAuthRedirectTests(TestCase):
+    """Unit tests for the shared post-authentication redirect helper."""
+
+    def _future(self):
+        return datetime.timestamp(datetime.now() + timedelta(minutes=15))
+
+    def _past(self):
+        return datetime.timestamp(datetime.now() - timedelta(minutes=1))
+
+    def test_valid_next_wins(self):
+        session = {'next': '/somewhere/', 'next_expiration': self._future()}
+        self.assertEqual(
+            resolve_post_auth_redirect(session, '/fallback/'), '/somewhere/'
+        )
+
+    def test_expired_next_is_ignored(self):
+        session = {'next': '/somewhere/', 'next_expiration': self._past()}
+        self.assertEqual(
+            resolve_post_auth_redirect(session, '/fallback/'), '/fallback/'
+        )
+
+    def test_next_without_expiration_is_ignored(self):
+        session = {'next': '/somewhere/'}
+        self.assertEqual(
+            resolve_post_auth_redirect(session, '/fallback/'), '/fallback/'
+        )
+
+    def test_first_login_goes_to_profile(self):
+        session = {'first_login': True}
+        self.assertEqual(
+            resolve_post_auth_redirect(session, '/fallback/'),
+            reverse('profiles:user_profile'),
+        )
+
+    def test_next_takes_priority_over_first_login(self):
+        session = {
+            'next': '/somewhere/',
+            'next_expiration': self._future(),
+            'first_login': True,
+        }
+        self.assertEqual(
+            resolve_post_auth_redirect(session, '/fallback/'), '/somewhere/'
+        )
+
+    def test_fallback_when_nothing_set(self):
+        self.assertEqual(
+            resolve_post_auth_redirect({}, '/fallback/'), '/fallback/'
+        )

--- a/profiles/tests/test_security_headers.py
+++ b/profiles/tests/test_security_headers.py
@@ -1,0 +1,18 @@
+from http import HTTPStatus
+
+from django.test import TestCase
+
+
+class SecurityHeadersTests(TestCase):
+    """The always-on security headers must be present on normal responses.
+
+    These three don't depend on HTTPS/DEBUG, so they're asserted directly.
+    HSTS and the SSL redirect are env-gated and verified at deploy time.
+    """
+
+    def test_security_headers_present_on_home(self):
+        response = self.client.get('/')
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response.headers.get('X-Content-Type-Options'), 'nosniff')
+        self.assertEqual(response.headers.get('X-Frame-Options'), 'DENY')
+        self.assertEqual(response.headers.get('Referrer-Policy'), 'same-origin')

--- a/profiles/tests/test_signup.py
+++ b/profiles/tests/test_signup.py
@@ -1,6 +1,7 @@
 from http import HTTPStatus
 from unittest.mock import patch
 
+from django.core import mail
 from django.test import TestCase
 from django.urls import reverse
 
@@ -21,10 +22,16 @@ class SignupEmailFailureTests(TestCase):
         }
 
     def test_signup_sends_email(self):
-        """Normal signup sends a confirmation email."""
+        """Normal signup dispatches a confirmation email to the new address.
+
+        Backend-agnostic: asserts the message actually reaches the outbox, so
+        the SendGrid->Brevo backend swap is provably non-breaking.
+        """
         response = self.client.post(reverse('profiles:signup'), data=self._signup_data())
         self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertTrue(User.objects.filter(email='new@test.com').exists())
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn('new@test.com', mail.outbox[0].to)
 
     @patch('profiles.views.user_create_confirm_email')
     def test_signup_survives_email_failure(self, mock_email):

--- a/profiles/tests/test_signup.py
+++ b/profiles/tests/test_signup.py
@@ -117,3 +117,15 @@ class SignupDisposableEmailTests(TestCase):
         )
         self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertTrue(User.objects.filter(email='real@stanford.edu').exists())
+
+    def test_allows_rambler(self):
+        """rambler.ru is a mainstream webmail provider, not disposable —
+        blocking it rejects legitimate researchers."""
+        response = self.client.post(
+            reverse('profiles:signup'),
+            data=self._signup_data('researcher@rambler.ru'),
+        )
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
+        self.assertTrue(
+            User.objects.filter(email='researcher@rambler.ru').exists()
+        )

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -36,6 +36,7 @@ from django.views.generic import (
     TemplateView,
 )
 from django.views.generic.edit import ModelFormMixin
+from django_ratelimit.decorators import ratelimit
 from rest_framework import viewsets
 
 from dal.autocomplete import Select2QuerySetView
@@ -203,6 +204,16 @@ class ProfileDetail(DetailView):
     query_pk_and_slug = True
 
 
+def _login_ratelimit_rate(group, request):
+    # Read the rate from settings at call time so it can be tuned via env
+    # (LOGIN_RATELIMIT) and overridden in tests.
+    return settings.LOGIN_RATELIMIT
+
+
+@method_decorator(
+    ratelimit(key='ip', rate=_login_ratelimit_rate, method='POST', block=False),
+    name='post',
+)
 class LoginView(auth_views.LoginView):
     form_class = AuthenticationForm
 
@@ -220,6 +231,17 @@ class LoginView(auth_views.LoginView):
                     datetime.now() + timedelta(minutes=15)
                 )
         return super().dispatch(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        # The ratelimit decorator (block=False) sets request.limited; surface a
+        # friendly message and re-render instead of authenticating.
+        if getattr(request, 'limited', False):
+            messages.error(
+                request,
+                'Too many login attempts. Please wait a moment and try again.',
+            )
+            return self.form_invalid(self.get_form())
+        return super().post(request, *args, **kwargs)
 
     def get_redirect_url(self):
         return resolve_post_auth_redirect(

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -59,6 +59,7 @@ from .forms import (
     UserProfileForm,
 )
 from .models import Country, Profile, Publication, Recommendation, User
+from .redirects import resolve_post_auth_redirect
 from .serializers import (
     CountrySerializer, PositionsCountSerializer, ProfileSearchSerializer,
 )
@@ -221,17 +222,9 @@ class LoginView(auth_views.LoginView):
         return super().dispatch(request, *args, **kwargs)
 
     def get_redirect_url(self):
-        if self.request.session.get('next') and \
-                self.request.session.get('next_expiration'):
-            if datetime.timestamp(
-                datetime.now()
-            ) < self.request.session['next_expiration']:
-                return self.request.session.get('next')
-
-        if self.request.session.get('first_login', False):
-            return reverse('profiles:user_profile')
-
-        return super().get_redirect_url()
+        return resolve_post_auth_redirect(
+            self.request.session, super().get_redirect_url()
+        )
 
 
 class UserProfileView(TemplateView):
@@ -568,17 +561,9 @@ class UserCreateConfirmView(TemplateView):
         return redirect('profiles:login')
 
     def get_redirect_url(self):
-        if self.request.session.get('next') and \
-                self.request.session.get('next_expiration'):
-            if datetime.timestamp(
-                datetime.now()
-            ) < self.request.session['next_expiration']:
-                return self.request.session.get('next')
-
-        if self.request.session.get('first_login', False):
-            return reverse('profiles:user_profile')
-
-        return reverse('profiles:user')
+        return resolve_post_auth_redirect(
+            self.request.session, reverse('profiles:user')
+        )
 
 
 class UserPasswordResetView(FormView):

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ django-extensions==3.1.1
 django-multiselectfield==0.1.12
 django-recaptcha==2.0.6
 django-robots==6.1
-django-sendgrid-v5==1.1.1
 
 # MySQL (production)
 mysqlclient>=2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ django-crispy-forms==1.14.0
 crispy-bootstrap5==0.6
 django-extensions==3.1.1
 django-multiselectfield==0.1.12
+django-ratelimit==4.1.0
 django-recaptcha==2.0.6
 django-robots==6.1
 

--- a/winrepo/settings.py
+++ b/winrepo/settings.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 from decouple import config
 
@@ -9,6 +10,9 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = config('SECRET_KEY')
 DEBUG = config('DEBUG', default=False, cast=bool)
 ENV = config('ENV', default='Local')
+
+# True while running the Django test suite (manage.py test).
+TESTING = 'test' in sys.argv
 
 # Google Maps JS API key used by the home page geochart (front-end, referrer-restricted).
 GOOGLE_MAPS_API_KEY = config('GOOGLE_MAPS_API_KEY', default='')
@@ -221,6 +225,17 @@ SECURE_SSL_REDIRECT = config('SECURE_SSL_REDIRECT', default=False, cast=bool)
 SECURE_HSTS_SECONDS = config('SECURE_HSTS_SECONDS', default=0, cast=int)
 SECURE_HSTS_INCLUDE_SUBDOMAINS = config('SECURE_HSTS_INCLUDE_SUBDOMAINS', default=True, cast=bool)
 SECURE_HSTS_PRELOAD = config('SECURE_HSTS_PRELOAD', default=True, cast=bool)
+
+# --- Rate limiting (django-ratelimit) ---
+# Protects the login endpoint from brute force. Disabled automatically under
+# the test runner so it can't interfere with other tests; the dedicated
+# rate-limit tests re-enable it explicitly. Acts as a kill-switch in prod:
+# set RATELIMIT_ENABLE=false if it ever causes trouble. Counters use Django's
+# default (local-memory) cache — per-process, but enough to blunt brute force.
+RATELIMIT_ENABLE = config('RATELIMIT_ENABLE', default=not TESTING, cast=bool)
+# Per-IP limit on login POSTs. Generous enough for shared/NAT'd networks
+# (universities) while still bounding password-guessing.
+LOGIN_RATELIMIT = config('LOGIN_RATELIMIT', default='10/m')
 
 SITE_ID = config('SITE_ID', cast=int, default=1)
 ROBOTS_CACHE_TIMEOUT = 60 * 60 * 24

--- a/winrepo/settings.py
+++ b/winrepo/settings.py
@@ -232,7 +232,9 @@ SECURE_HSTS_PRELOAD = config('SECURE_HSTS_PRELOAD', default=True, cast=bool)
 # rate-limit tests re-enable it explicitly. Acts as a kill-switch in prod:
 # set RATELIMIT_ENABLE=false if it ever causes trouble. Counters use Django's
 # default (local-memory) cache — per-process, but enough to blunt brute force.
-RATELIMIT_ENABLE = config('RATELIMIT_ENABLE', default=not TESTING, cast=bool)
+# Force-disabled under the test runner (regardless of env) so it can't make
+# other tests flaky; the dedicated rate-limit tests re-enable it explicitly.
+RATELIMIT_ENABLE = config('RATELIMIT_ENABLE', default=True, cast=bool) and not TESTING
 # Per-IP limit on login POSTs. Generous enough for shared/NAT'd networks
 # (universities) while still bounding password-guessing.
 LOGIN_RATELIMIT = config('LOGIN_RATELIMIT', default='10/m')

--- a/winrepo/settings.py
+++ b/winrepo/settings.py
@@ -201,6 +201,27 @@ EMAIL_FROM = config('DEFAULT_FROM_EMAIL')
 EMAIL_REPLY_TO = config('DEFAULT_REPLY_TO_EMAIL')
 EMAIL_SUBJECT_PREFIX = 'WiNRepo - '
 
+# --- Security headers (Django deployment checklist) ---
+# Always on — safe in both dev and prod, no HTTPS dependency:
+SECURE_CONTENT_TYPE_NOSNIFF = True       # X-Content-Type-Options: nosniff
+SECURE_REFERRER_POLICY = 'same-origin'   # Referrer-Policy
+X_FRAME_OPTIONS = 'DENY'                  # clickjacking (middleware already enabled)
+
+# HTTPS hardening — only outside local dev (DEBUG) so http://localhost keeps
+# working. winrepo.org is served over HTTPS; PythonAnywhere terminates TLS at
+# its proxy and forwards X-Forwarded-Proto, which we trust here.
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+SESSION_COOKIE_SECURE = not DEBUG
+CSRF_COOKIE_SECURE = not DEBUG
+# HSTS and the HTTP->HTTPS redirect are env-gated (default off) so they can be
+# switched on deliberately once verified on PythonAnywhere — an unverified
+# SSL redirect behind a proxy can cause a redirect loop, and HSTS is a
+# hard browser commitment for its full duration.
+SECURE_SSL_REDIRECT = config('SECURE_SSL_REDIRECT', default=False, cast=bool)
+SECURE_HSTS_SECONDS = config('SECURE_HSTS_SECONDS', default=0, cast=int)
+SECURE_HSTS_INCLUDE_SUBDOMAINS = config('SECURE_HSTS_INCLUDE_SUBDOMAINS', default=True, cast=bool)
+SECURE_HSTS_PRELOAD = config('SECURE_HSTS_PRELOAD', default=True, cast=bool)
+
 SITE_ID = config('SITE_ID', cast=int, default=1)
 ROBOTS_CACHE_TIMEOUT = 60 * 60 * 24
 

--- a/winrepo/settings.py
+++ b/winrepo/settings.py
@@ -185,9 +185,10 @@ RECAPTCHA_PUBLIC_KEY = config('RECAPTCHA_PUBLIC_KEY')
 RECAPTCHA_PRIVATE_KEY = config('RECAPTCHA_PRIVATE_KEY')
 RECAPTCHA_DOMAIN = config('RECAPTCHA_DOMAIN')
 
+# Email is sent over plain SMTP. Production uses Brevo's relay
+# (smtp-relay.brevo.com:587, TLS); set EMAIL_HOST/PORT/USER/PASSWORD in the
+# environment. Local dev leaves these empty and prints to the console.
 EMAIL_BACKEND = config('EMAIL_BACKEND', default='django.core.mail.backends.smtp.EmailBackend')
-SENDGRID_API_KEY = config('SENDGRID_API_KEY', default='')
-SENDGRID_SANDBOX_MODE_IN_DEBUG = False
 EMAIL_HOST = config('EMAIL_HOST', default='')
 EMAIL_PORT = config('EMAIL_PORT', default=25, cast=int)
 EMAIL_HOST_USER = config('EMAIL_HOST_USER', default='')


### PR DESCRIPTION
## Summary

First of two PRs for **Phase 1** (operational continuity + contributor onboarding). This part covers everything that does **not** require PythonAnywhere/Brevo credentials: the email-backend code migration, security hardening, code-quality cleanups, and contributor docs. A follow-up PR will cover the Brevo production cutover and the MySQL end-of-life update once infra access is available.

All changes are test-backed: **82 passing tests (+11 new this branch).**

## What's included

**Email**
- Drop the dead SendGrid config (`SENDGRID_*` were read into settings but referenced nowhere) and the `django-sendgrid-v5` dependency; document the Brevo SMTP relay in `.env.default`. The backend already defaults to Django SMTP, so the production cutover is just setting Brevo env vars (follow-up PR).
- Lock in signup delivery behaviour with an outbox assertion, so the backend swap is provably non-breaking.

**Security hardening**
- Security headers: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: same-origin` always on; secure cookies outside `DEBUG`; HSTS + HTTP→HTTPS redirect env-gated (default off) to switch on deliberately after verifying HTTPS on PythonAnywhere. _Closes #7._
- Rate-limit the login endpoint (`django-ratelimit`, per-IP, default `10/m`, friendly re-render on limit, `RATELIMIT_ENABLE` kill-switch, auto-disabled under the test runner). _Closes #8._
- Stop blocking `rambler.ru` as disposable — it's a mainstream webmail provider, so the rule was rejecting legitimate researchers.

**Code quality**
- Extract the duplicated post-auth redirect logic (copy-pasted in `LoginView`, `UserCreateConfirmView`, and the allauth account adapter) into `profiles/redirects.resolve_post_auth_redirect`, removing the standing `TODO`. _Closes #10._
- Replace the fragile `user_logged_in` receiver-list rotation with scoped, idempotent ordering (the audit's "signal manipulation" item).

**Docs**
- Expand `CONTRIBUTING.md` for the summer volunteers: dev setup, test-before-touch workflow, conventional commits, project map, helper-script reference.

## Deploy notes
- ⚠️ **New dependency** `django-ratelimit==4.1.0` (`requirements.txt` updated; the deploy script `pip install`s it). Smoke-test login after deploy.
- Security headers: to enable the HTTPS redirect + HSTS, set `SECURE_SSL_REDIRECT` / `SECURE_HSTS_SECONDS` once HTTPS is verified on PythonAnywhere.
- Rate limiting uses Django's default local-memory cache (per-process — enough to blunt brute force; can be made shared later).

## Not in this PR (follow-up, part 2)
- Brevo **production cutover** (set SMTP env vars on PythonAnywhere + verify deliverability).
- MySQL **end-of-life update** (spike-gated; needs PA access).
- Google Drive mirror of the contributor docs.

Closes #7, #8, #10.
